### PR TITLE
Add partial matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,20 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+Layout/FirstHashElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
 Layout/LineLength:
   Enabled: true
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Enabled: true
   CountAsOne: ['array', 'heredoc', 'method_call']
+  Exclude: ['test/**/*']
 
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -50,6 +51,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: true
   CountAsOne: ['array', 'heredoc', 'method_call']
+
+Minitest/MultipleAssertions:
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ OPTIONS
       2. alpha3 (ISO3166 standard 3 letter code)
       3. number (ISO3166 standard 3 digit code)
       4. name   (common, localized, unofficial)
+      5. partial match on name
 
   -r/--region
     : Display all countries by subregion
@@ -76,6 +77,7 @@ OPTIONS
       1. code   (ISO4127 standard 3 letter code)
       2. name   (ISO4127 standard name)
       3. symbol
+      4. partial match on name
 
   -h/--help
     : Display this page

--- a/lib/atlasq.rb
+++ b/lib/atlasq.rb
@@ -9,6 +9,7 @@ module Atlasq
   autoload :Command, "atlasq/command"
   autoload :Data, "atlasq/data"
   autoload :Format, "atlasq/format"
+  autoload :PartialMatch, "atlasq/partial_match"
   autoload :Shell, "atlasq/shell"
   autoload :Util, "atlasq/util"
 

--- a/lib/atlasq/command.rb
+++ b/lib/atlasq/command.rb
@@ -17,6 +17,7 @@ module Atlasq
     def self.parse(args)
       command = parse_command(args.first)
       args.shift unless command.to_s == "Atlasq::Command::Any"
+      args.map!(&:strip)
 
       Options.new(command: command, args: args).freeze
     end

--- a/lib/atlasq/command/country.rb
+++ b/lib/atlasq/command/country.rb
@@ -12,10 +12,13 @@ module Atlasq
           Format.countries(countries, title: "All Countries")
         else
           search_terms.map do |term|
-            country = Data.country(term)
-
-            if country
+            if (country = Data.country(term))
               Format.country(country, term)
+            elsif (country_codes = PartialMatch.countries(term)).any?
+              countries = country_codes.map do |code|
+                Data.country_by_code(code)
+              end
+              Format.countries(countries, title: "Countries (Partial Match)")
             else
               Atlasq.failed!
               "Unknown country: #{term}"

--- a/lib/atlasq/command/help.rb
+++ b/lib/atlasq/command/help.rb
@@ -41,6 +41,7 @@ module Atlasq
                 2. alpha3 (ISO3166 standard 3 letter code)
                 3. number (ISO3166 standard 3 digit code)
                 4. name   (common, localized, unofficial)
+                5. partial match on name
 
             -r/--region
               : Display all countries by subregion
@@ -58,6 +59,7 @@ module Atlasq
                 1. code   (ISO4127 standard 3 letter code)
                 2. name   (ISO4127 standard name)
                 3. symbol
+                4. partial match on name
 
             -h/--help
               : Display this page

--- a/lib/atlasq/command/money.rb
+++ b/lib/atlasq/command/money.rb
@@ -11,13 +11,16 @@ module Atlasq
           Format.currencies(currencies)
         else
           search_terms.map do |term|
-            currencies = Data.currencies(term)
-
-            if currencies.empty?
+            if (currencies = Data.currencies(term)).any?
+              Format.currencies(currencies)
+            elsif (currency_codes = PartialMatch.currencies(term)).any?
+              currencies = currency_codes.filter_map do |code|
+                Data.currency_by_code(code)
+              end
+              Format.currencies(currencies, partial_match: true)
+            else
               Atlasq.failed!
               "Unknown currency: #{term}"
-            else
-              Format.currencies(currencies)
             end
           end.join("\n\n")
         end

--- a/lib/atlasq/data.rb
+++ b/lib/atlasq/data.rb
@@ -39,12 +39,18 @@ module Atlasq
     end
 
     # @param term [String]
-    # @return [ISO3166::Country|nil]
+    # @return [ISO3166::Country, nil]
     def self.country(term)
       ISO3166::Country.find_country_by_alpha2(term) ||
         ISO3166::Country.find_country_by_alpha3(term) ||
         ISO3166::Country.find_country_by_number(term) ||
         ISO3166::Country.find_country_by_any_name(term)
+    end
+
+    # @param code [String] 3 digit country id
+    # @return [ISO3166::Country, nil]
+    def self.country_by_code(code)
+      ISO3166::Country.find_country_by_number(code)
     end
 
     # @return [Array<ISO3166::Country>]
@@ -55,7 +61,7 @@ module Atlasq
     # Region types for querying ISO3166::Country
     REGION_TYPES = %i[region subregion world_region continent].freeze
 
-    # @return [Atlasq::Data::Region|nil]
+    # @return [Atlasq::Data::Region, nil]
     def self.region(term)
       REGION_TYPES.each do |region_type|
         countries = ISO3166::Country.find_all_by(region_type, term)

--- a/lib/atlasq/data.rb
+++ b/lib/atlasq/data.rb
@@ -88,13 +88,22 @@ module Atlasq
     # @param term [String]
     # @return [Array<Atlasq::Data::Currency>]
     def self.currencies(term)
-      currency_codes = Money::Currency.analyze(term)
-      currency_codes.filter_map do |currency_code|
+      currency_codes = currency_code_by_number(term) || Money::Currency.analyze(term)
+      Array(currency_codes).filter_map do |currency_code|
         countries = ISO3166::Country.find_all_by(:currency_code, currency_code)
         next if countries.empty?
 
         Currency.new(countries: countries.values, currency_code: currency_code)
       end
+    end
+
+    # @param term [String] 3 digit currency code (ISO4217)
+    # @return [String, nil] 3 letter currency code (ISO4217)
+    def self.currency_code_by_number(term)
+      @currency_code_by_number ||= all_countries
+        .to_h { |country| [country.currency.iso_numeric, country.currency.iso_code] }
+
+      @currency_code_by_number[term]
     end
 
     # @param code [String] 3 letter currency code (ISO4217)

--- a/lib/atlasq/data.rb
+++ b/lib/atlasq/data.rb
@@ -97,6 +97,15 @@ module Atlasq
       end
     end
 
+    # @param code [String] 3 letter currency code (ISO4217)
+    # @return [Atlasq::Data::Currency, nil]
+    def self.currency_by_code(code)
+      countries = ISO3166::Country.find_all_by(:currency_code, code)
+      return if countries.empty?
+
+      Currency.new(countries: countries.values, currency_code: code)
+    end
+
     # @return [Array<Atlasq::Data::Currency>]
     def self.all_currencies
       all_countries

--- a/lib/atlasq/format.rb
+++ b/lib/atlasq/format.rb
@@ -200,8 +200,9 @@ module Atlasq
     end
 
     # @param currencies [Array<Atlasq::Data::Currencies]
+    # @param partial_match [Boolean] defaults to false
     # @return [String]
-    def self.currencies(currencies)
+    def self.currencies(currencies, partial_match: false)
       currencies = currencies.to_h do |currency_class|
         currency = Money::Currency.new(currency_class.currency_code)
 
@@ -211,12 +212,13 @@ module Atlasq
         ]
       end
 
-      if currencies.size == 1
+      if !partial_match && currencies.size == 1
         title, elements = currencies.first
         title = "Currency: #{title}"
         Format.brief_template(title: title, elements: elements)
       else
-        Format.brief_template(title: "Currencies", elements: currencies)
+        title = partial_match ? "Currencies (Partial Match)" : "Currencies"
+        Format.brief_template(title: title, elements: currencies)
       end
     end
   end

--- a/lib/atlasq/partial_match.rb
+++ b/lib/atlasq/partial_match.rb
@@ -3,7 +3,7 @@
 module Atlasq
   module PartialMatch
     # @param term [String]
-    # @return [Array<String>] 3 digit country codes
+    # @return [Array<String>] 3 digit country codes (ISO3166)
     def self.countries(term)
       @countries ||= begin
         id_to_country_names = Data
@@ -24,6 +24,20 @@ module Atlasq
       end
 
       @countries.search(term)
+    end
+
+    # @param term [String]
+    # @return [Array<String>] 3 letter currency codes (ISO4217)
+    def self.currencies(term)
+      @currencies ||= begin
+        id_to_currency_names = Data
+          .all_countries
+          .to_h { |country| [country.currency.iso_code, [country.currency.name]] }
+
+        Util::WordMap.new(id_to_currency_names)
+      end
+
+      @currencies.search(term)
     end
   end
 end

--- a/lib/atlasq/partial_match.rb
+++ b/lib/atlasq/partial_match.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Atlasq
+  module PartialMatch
+    # @param term [String]
+    # @return [Array<String>] 3 digit country codes
+    def self.countries(term)
+      @countries ||= begin
+        id_to_country_names = Data
+          .all_countries
+          .to_h do |country|
+            [
+              country.number,
+              [
+                country.iso_short_name,
+                country.iso_long_name,
+                *country.unofficial_names,
+                *country.translated_names
+              ]
+            ]
+          end
+
+        Util::WordMap.new(id_to_country_names)
+      end
+
+      @countries.search(term)
+    end
+  end
+end

--- a/lib/atlasq/util.rb
+++ b/lib/atlasq/util.rb
@@ -3,5 +3,6 @@
 module Atlasq
   module Util
     autoload :String, "atlasq/util/string"
+    autoload :WordMap, "atlasq/util/word_map"
   end
 end

--- a/lib/atlasq/util/string.rb
+++ b/lib/atlasq/util/string.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "unaccent"
+
 module Atlasq
   module Util
     module String
@@ -11,6 +13,15 @@ module Atlasq
           .split(/[-_ \t]+/)
           .map(&:capitalize)
           .join(" ")
+      end
+
+      # Make string lowercase and remove accents.
+      #
+      # @param string [String]
+      # @return [String]
+      def self.normalize(string)
+        @normalize ||= {}
+        @normalize[string] ||= Unaccent.unaccent(string.downcase)
       end
     end
   end

--- a/lib/atlasq/util/word_map.rb
+++ b/lib/atlasq/util/word_map.rb
@@ -45,7 +45,7 @@ module Atlasq
               .flat_map { |string| split(string) }
               .map { |word| Util::String.normalize(word) }
               .uniq
-            
+
             words.each do |word|
               word_map[word] << id
             end
@@ -61,7 +61,7 @@ module Atlasq
       # @param sentence [String]
       # @return [Array<String>]
       def split(sentence)
-        sentence.split(/[ \t,;:()]+/)
+        sentence.split(/[ \t,;:()]+/).reject(&:empty?)
       end
     end
   end

--- a/lib/atlasq/util/word_map.rb
+++ b/lib/atlasq/util/word_map.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "set"
+require "unaccent"
+
+module Atlasq
+  module Util
+    # This data structure provides partial match support for words in sentences.
+    #
+    # For example, if we take a country like "Bonaire, Sint Eustatius and Saba"
+    # the searches "Bonaire", "Sint Eustatius" and "saba bonaire" should all match
+    # while the searches "bonaire france" and "saba bolivia" should not because
+    # they include words not found in the original sentence.
+    class WordMap
+      # @param id_to_raw_names [Hash<String, Array<String>>]
+      def initialize(id_to_raw_names)
+        @id_to_raw_names = id_to_raw_names
+      end
+
+      # Search for ids that include all of the search term words.
+      #
+      # @param search_term [String]
+      # @return [Array<String>] list of ids
+      def search(search_term)
+        search_term
+          .then { |string| split(string) }
+          .map { |word| Util::String.normalize(word) }
+          .uniq
+          .map { |word| word_map[word] }
+          .inject(&:intersection)
+          .sort
+      end
+
+      private
+
+      # A map of words to ids.
+      #
+      # @return [Hash<String, Set<String>>]
+      def word_map
+        @word_map ||= begin
+          word_map = Hash.new { |hash, key| hash[key] = Set.new }
+
+          @id_to_raw_names.each do |id, raw_names|
+            words = raw_names
+              .flat_map { |string| split(string) }
+              .map { |word| Util::String.normalize(word) }
+              .uniq
+            
+            words.each do |word|
+              word_map[word] << id
+            end
+          end
+
+          word_map
+        end
+      end
+
+      # Split on spaces, tabs and punctuation separators.
+      # Note: Some punctuation can be connectors or separators based on the language.
+      #
+      # @param sentence [String]
+      # @return [Array<String>]
+      def split(sentence)
+        sentence.split(/[ \t,;:()]+/)
+      end
+    end
+  end
+end

--- a/test/test_shell.rb
+++ b/test/test_shell.rb
@@ -271,6 +271,44 @@ class ShellTest < Minitest::Test
     end
   end
 
+  def test_currency_partial_match_output
+    expected_output = <<~OUTPUT
+      *
+      * Currencies (Partial Match)
+      * * * * * * * * * * * * * * * *
+      - [EGP] ج.م Egyptian Pound
+          (🇪🇬 | 818 | EG | EGY | Egypt)
+      - [FKP] £ Falkland Pound
+          (🇫🇰 | 238 | FK | FLK | Falkland Islands (Malvinas))
+      - [GBP] £ British Pound
+          (🇬🇧 | 826 | GB | GBR | United Kingdom of Great Britain and Northern Ireland)
+          (🇬🇬 | 831 | GG | GGY | Guernsey)
+          (🇬🇸 | 239 | GS | SGS | South Georgia and the South Sandwich Islands)
+          (🇮🇲 | 833 | IM | IMN | Isle of Man)
+          (🇯🇪 | 832 | JE | JEY | Jersey)
+      - [GIP] £ Gibraltar Pound
+          (🇬🇮 | 292 | GI | GIB | Gibraltar)
+      - [LBP] ل.ل Lebanese Pound
+          (🇱🇧 | 422 | LB | LBN | Lebanon)
+      - [SDG] £ Sudanese Pound
+          (🇸🇩 | 729 | SD | SDN | Sudan)
+      - [SHP] £ Saint Helenian Pound
+          (🇸🇭 | 654 | SH | SHN | Saint Helena, Ascension and Tristan da Cunha)
+      - [SSP] £ South Sudanese Pound
+          (🇸🇸 | 728 | SS | SSD | South Sudan)
+      - [SYP] £S Syrian Pound
+          (🇸🇾 | 760 | SY | SYR | Syrian Arab Republic)
+    OUTPUT
+
+    %w[-m --money].each do |command|
+      actual_output, _err = capture_io do
+        Atlasq::Shell.start!([command, "pound"])
+      end
+
+      assert_equal expected_output, actual_output
+    end
+  end
+
   def test_all_currencies_output
     expected_output = fixture("all_currencies_output.txt")
 

--- a/test/test_shell.rb
+++ b/test/test_shell.rb
@@ -45,6 +45,29 @@ class ShellTest < Minitest::Test
     end
   end
 
+  def test_country_partial_match_output
+    expected_output = <<~OUTPUT
+      *
+      * Countries (Partial Match)
+      * * * * * * * * * * * * * * *
+      (🇦🇪 | 784 | AE | ARE | United Arab Emirates)
+      (🇬🇧 | 826 | GB | GBR | United Kingdom of Great Britain and Northern Ireland)
+      (🇲🇽 | 484 | MX | MEX | Mexico)
+      (🇹🇿 | 834 | TZ | TZA | Tanzania, United Republic of)
+      (🇺🇲 | 581 | UM | UMI | United States Minor Outlying Islands)
+      (🇺🇸 | 840 | US | USA | United States of America)
+      (🇻🇮 | 850 | VI | VIR | Virgin Islands (U.S.))
+    OUTPUT
+
+    %w[-c --country --countries].each do |command|
+      actual_output, _err = capture_io do
+        Atlasq::Shell.start!([command, "united"])
+      end
+
+      assert_equal expected_output, actual_output
+    end
+  end
+
   def test_all_countries_output
     expected_output = fixture("all_countries_output.txt")
 

--- a/test/test_shell.rb
+++ b/test/test_shell.rb
@@ -260,7 +260,7 @@ class ShellTest < Minitest::Test
     OUTPUT
 
     commands = %w[-m --money]
-    currencies = ["BHD", "Bahraini Dinar"]
+    currencies = ["BHD", "048", "Bahraini Dinar"]
 
     commands.product(currencies).each do |args|
       actual_output, _err = capture_io do

--- a/test/test_util.rb
+++ b/test/test_util.rb
@@ -12,4 +12,19 @@ class UtilTest < Minitest::Test
       assert_equal "One Two Three", Atlasq::Util::String.titleize(string)
     end
   end
+
+  def test_word_map_search
+    word_map = Atlasq::Util::WordMap.new({
+      "even" => ["2 4 6 8 10", "two four six eight ten"],
+      "odd" => ["1 3 5 7 9", "one three five seven nine"],
+      "digits" => ["1, 2, 3, 4, 5, 6, 7, 8, 9, 10"],
+      "tens" => ["10 20 30 40 50", "ten twenty thirty fourty fifty"]
+    })
+
+    assert_equal %w[digits even], word_map.search("2")
+    assert_equal %w[digits odd], word_map.search("9")
+    assert_equal %w[digits even tens], word_map.search("10")
+    assert_equal %w[tens], word_map.search("10;   twenty 30  (fourty) 50")
+    assert_empty word_map.search("eleven ten")
+  end
 end


### PR DESCRIPTION
Adds partial matching for countries and currencies. It also fixes a small bug where currencies couldn't be searched by ISO4217 number.

The biggest change here is the addition of the `Atlas::Util::WordMap` data structure which allows us to easily partially match a list of words to names. This allows `states united` and `united states` to match the same country.

Closes #4