### PR TITLE
Adds support for traditional and simplified chinese country name localizations

### DIFF
--- a/lib/atlasq/data.rb
+++ b/lib/atlasq/data.rb
@@ -21,7 +21,7 @@ ISO3166.configure do |config|
     pa pl ps pt ro ru rw si sk sl
     so sq sr sv sw ta te th ti tk
     tl tr tt ug uk ve vi wa wo xh
-    zh zu
+    zh-CN zh-TW zu
   ]
 end
 


### PR DESCRIPTION
This was not included by accident last time. I think I just copied the list of locales from the countries gem guide last time without checking.