### PR TITLE
Remove money heuristics gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       countries (~> 5.7)
       iso-639 (~> 0.3)
       money (~> 6.9)
-      money-heuristics (~> 0.1.1)
       tty-pager (~> 0.14)
 
 GEM
@@ -23,9 +22,6 @@ GEM
     minitest (5.20.0)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
-    money-heuristics (0.1.1)
-      money (>= 6.9.0)
-      sixarm_ruby_unaccent (>= 1.1.1, < 2)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -53,7 +49,6 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
-    sixarm_ruby_unaccent (1.2.2)
     strings (0.2.1)
       strings-ansi (~> 0.2)
       unicode-display_width (>= 1.5, < 3.0)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $ atlasq --money Surinamese\ Dollar
 
 Country data is sourced from the [countries](https://github.com/countries/countries) gem which provides country and region information and implements the ISO3166 standard country codes and names.
 
-Currency data is sourced from from the [money](https://github.com/RubyMoney/money) and [money-heuristics](https://github.com/RubyMoney/money-heuristics) gems which provide information about currency names and symbols.
+Currency data is sourced from the [money](https://github.com/RubyMoney/money) gem which provides information about currency names and symbols.
 
 Language data is sourced from the [ISO-639](https://github.com/xwmx/iso-639) gem which implements the ISO369 standard for language codes and names.
 

--- a/atlasq.gemspec
+++ b/atlasq.gemspec
@@ -29,6 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "countries", "~> 5.7"
   spec.add_dependency "iso-639", "~> 0.3"
   spec.add_dependency "money", "~> 6.9"
-  spec.add_dependency "money-heuristics", "~> 0.1.1"
   spec.add_dependency "tty-pager", "~> 0.14"
 end

--- a/lib/atlasq/data.rb
+++ b/lib/atlasq/data.rb
@@ -3,7 +3,6 @@
 require "countries"
 require "iso-639"
 require "money"
-require "money-heuristics"
 
 # Needed to allow us to access the `ISO3166::Country#currency`
 # object which ends up being an instance of `Money::Currency`.

--- a/script/generate_readme.rb
+++ b/script/generate_readme.rb
@@ -77,7 +77,7 @@ puts <<~README
 
   Country data is sourced from the [countries](https://github.com/countries/countries) gem which provides country and region information and implements the ISO3166 standard country codes and names.
 
-  Currency data is sourced from from the [money](https://github.com/RubyMoney/money) and [money-heuristics](https://github.com/RubyMoney/money-heuristics) gems which provide information about currency names and symbols.
+  Currency data is sourced from the [money](https://github.com/RubyMoney/money) gem which provides information about currency names and symbols.
 
   Language data is sourced from the [ISO-639](https://github.com/xwmx/iso-639) gem which implements the ISO369 standard for language codes and names.
 

--- a/script/generate_search_index.rb
+++ b/script/generate_search_index.rb
@@ -9,7 +9,6 @@ require_relative "shared/cache_generator"
 require "countries"
 require "iso-639"
 require "money"
-require "money-heuristics"
 
 ISO3166.configure do |config|
   # Needed to allow us to access the `ISO3166::Country#currency`


### PR DESCRIPTION
The last reference to this was removed when I changed things to use the cached search indexes. I wasn't using the feature much either beforehand and now it's not necessary anymore.