### PR TITLE
Include country gems in IRB

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-
 require "atlasq"
-require "atlasq/data"
-
 require "irb"
+
+require_relative "../script/shared/country_info"
+
 IRB.start(__FILE__)


### PR DESCRIPTION
These were removed as runtime dependencies in a previous commit so they need to be explicitly included from the script/shared/ directory.