### PR TITLE
Add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.1'
         bundler-cache: true
 
     - name: Outdated readme check
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Git repository


### PR DESCRIPTION
This got released at the end of the December in the yearly Ruby Christmas tradition so things need to be updated here. I don't expect anything to fail but we'll see.

Fixes #29.