### PR TITLE
Fix caching bug

### DIFF
--- a/lib/atlasq/cache.rb
+++ b/lib/atlasq/cache.rb
@@ -13,14 +13,11 @@ module Atlasq
       @get ||= {}
       @get.fetch(full_name) do
         path = "#{CACHE_DIR}/#{full_name}"
-        content = File.read(path)
 
-        case full_name
-        when /\.json$/
-          JSON.parse(content)
-        else
-          content
-        end
+        content = File.read(path)
+        content = JSON.parse(content) if full_name.end_with?(".json")
+
+        @get[full_name] = content
       end
     end
   end


### PR DESCRIPTION
We had a cache when loading the cached json and text files which was not actually caching anything. This caused files to be read from disk in a loop instead of just being read the first time.