### PR TITLE
Update supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     needs: docs
     strategy:
       matrix:
-        platform: ["ubuntu-latest", "macos-latest"]
+        platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
         ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     needs: docs
     strategy:
       matrix:
-        platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        platform: ["ubuntu-latest", "macos-latest"]
         ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Git repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Layout/FirstArrayElementIndentation:
   Enabled: true

--- a/atlasq.gemspec
+++ b/atlasq.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
     Query for regional info and see which countries show up.
   DESCRIPTION
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata = {
     "homepage_uri" => "https://github.com/apainintheneck/atlasq/",

--- a/exe/atlasq
+++ b/exe/atlasq
@@ -5,9 +5,6 @@ debug = true if ARGV.delete("-d")
 debug = true if ARGV.delete("--debug")
 ENV["ATLASQ_DEBUG"] = "1" if debug
 
-# Avoid warnings on Ruby 2.7 related to pattern matching.
-Warning[:experimental] = false
-
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "atlasq"
 


### PR DESCRIPTION
### Drop Ruby 2.7

This is not supported anymore as of March 31st 2023 and I have no
desire to support it indefinitely. Kill it with fire.

### Try Windows on CI

Local development makes use of some commands like diff that might
not be portable to windows but the app itself doesn't really use
much beyond basic Ruby. It might be cross-platform.