### PR TITLE
Prep for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.0] 2024-03-31
+
+- Drop support for Ruby 2.7
+
 ## [0.4.0] 2024-02-21
 
 - Fix bug in data caching where cache files were read multiple times

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atlasq (0.4.0)
+    atlasq (1.0.0)
       tty-pager (~> 0.14)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ OPTIONS
     : Display this page
 
   -v/--version
-    : Display the version (0.4.0)
+    : Display the version (1.0.0)
 
   -d/--debug
     : Display debug output

--- a/lib/atlasq/version.rb
+++ b/lib/atlasq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Atlasq
-  VERSION = "0.4.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
The only breaking change here is dropping support for Ruby 2.7. I did that a few weeks ago and now it looks like the countries gem has done the same thing. It was beyond end of life so that is not surprising.

Beyond that there were a bunch of small dependency updates but nothing really worth mentioning. You can look at the diff if you're curious.