### PR TITLE
Add unaccent gem as dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     atlasq (1.0.1)
-      tty-pager (~> 0.14)
+      tty-pager
+      unaccent
 
 GEM
   remote: https://rubygems.org/

--- a/atlasq.gemspec
+++ b/atlasq.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = ["atlasq"]
 
-  spec.add_dependency "tty-pager", "~> 0.14"
+  spec.add_dependency "tty-pager"
+  spec.add_dependency "unaccent"
 end


### PR DESCRIPTION
This was a transitive dependency of the countries gem that didn't get explicitly included when that gem got removed at runtime. I realized that there was a problem when I tried to install this gem on a new computer.